### PR TITLE
:bug: Fix node modules path

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,8 @@ function vConsolePlugin(options) {
 
 vConsolePlugin.prototype.apply = function(compiler) {
     const enable = this.options.enable;
-    let _root = path.join(compiler.context, '/node_modules'); // base to $project/node_modules
-
-    // support resolveLoader.root
-    if (compiler.options.resolveLoader && compiler.options.resolveLoader.root) {
-        _root = compiler.options.resolveLoader.root;
-    }
-
+    const modulePaths = module.paths;
+    let _root = modulePaths.find(path => fs.existsSync(path));
     const pathVconsole = path.join(_root, '/vconsole/dist/vconsole.min.js');
 
     compiler.plugin('entry-option', function() {


### PR DESCRIPTION
查找node_modules所在的文件位置有些问题，可以根据`module.paths`查找，`node`的`require('模块名')`也是根据`module.paths`去查找模块的。

我的目录结构如下，不能正确找到vconsole的文件位置

![image](https://user-images.githubusercontent.com/8096659/32423764-6c256736-c2e3-11e7-9eef-c63c5b45d305.png)
