### PR TITLE
添加过滤入口文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module.exports = {
 
     plugins: [
         new vConsolePlugin({
+            filter: [],  // 需要过滤的入口文件
             enable: true // 发布代码前记得改回 false
         }),
         ...

--- a/index.js
+++ b/index.js
@@ -12,25 +12,34 @@ const fs = require('fs');
 
 function vConsolePlugin(options) {
     this.options = Object.assign({
+        filter: [],
         enable: false // 插件开关，默认“关”
     }, options);
+    if (typeof this.options.filter === 'string') {
+        this.options.filter = [this.options.filter];
+    }
 }
 
 vConsolePlugin.prototype.apply = function(compiler) {
     const enable = this.options.enable;
     const _root = module.paths.find(path => fs.existsSync(path));
     const pathVconsole = path.join(_root, '/vconsole/dist/vconsole.min.js');
+    const that = this;
 
     compiler.plugin('entry-option', function() {
         if (enable) {
             if (Object.prototype.toString.call(this.options.entry) === '[object Array]') {
-                this.options.entry.unshift(pathVconsole);
+                if (!that.find(this.options.entry)) {
+                    this.options.entry.unshift(pathVconsole);
+                }
             } else if (typeof this.options.entry === 'object') {
                 for (let key in this.options.entry) {
-                    if (Object.prototype.toString.call(this.options.entry[key]) === '[object Array]') {
-                        this.options.entry[key].unshift(pathVconsole);
-                    } else if (typeof this.options.entry[key] === 'string') {
-                        this.options.entry[key] = [pathVconsole, this.options.entry[key]];
+                    if (that.options.filter.indexOf(key) === -1 ) {
+                        if (Object.prototype.toString.call(this.options.entry[key]) === '[object Array]') {
+                            this.options.entry[key].unshift(pathVconsole);
+                        } else if (typeof this.options.entry[key] === 'string') {
+                            this.options.entry[key] = [pathVconsole, this.options.entry[key]];
+                        }
                     }
                 }
             }
@@ -38,6 +47,16 @@ vConsolePlugin.prototype.apply = function(compiler) {
             // console.log(this.options.entry);
         }
     });
+};
+vConsolePlugin.prototype.find = function(arr){
+    for (var i = 0; i < arr.length; i++) {
+        for (var j = 0; j < this.options.filter.length; j++) {
+            if (this.options.filter[j] === arr[i]) {
+                return true
+            }
+        }
+    }
+    return false
 };
 
 module.exports = vConsolePlugin;


### PR DESCRIPTION
在filter里面的入口文件都不会被加入vconsole这个插件。

适用场景：
1. 通过webpack打包公用文件vendor (加入vconsole插件)
2. a模块中通过 require('vendor')引入上次打包文件的vendor(二次加入vconsole插件)，会出现2个console
 #6 
