### PR TITLE
添加在 PC 端禁用选项

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const fs = require('fs');
 function vConsolePlugin(options) {
     this.options = Object.assign({
         filter: [],
-        enable: false // 插件开关，默认“关”
+        enable: false, // 插件开关，默认“关”
+        disableInPC: false,
     }, options);
     if (typeof this.options.filter === 'string') {
         this.options.filter = [this.options.filter];
@@ -22,10 +23,12 @@ function vConsolePlugin(options) {
 }
 
 vConsolePlugin.prototype.apply = function(compiler) {
-    const enable = this.options.enable;
-    let pathVconsole = 'vconsole-webpack-plugin/src/vconsole.js';
+    const { enable, disableInPC } = this.options || {};
+    const loadFileName = disableInPC ? 'disable-in-pc.js' : 'vconsole.js';
+
+    let pathVconsole = `vconsole-webpack-plugin/src/${loadFileName}`;
     const _root = module.parent.paths.find(item => {
-        let tmpPathVconsole = path.join(item, 'vconsole-webpack-plugin/src/vconsole.js');
+        let tmpPathVconsole = path.join(item, `vconsole-webpack-plugin/src/${loadFileName}`);
         if (fs.existsSync(item) && fs.existsSync(tmpPathVconsole)) {
             pathVconsole = tmpPathVconsole;
             return true;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.2",
   "description": "webpack plugin for vConsole",
   "main": "index.js",
+  "typings": "./types.d.ts",
   "scripts": {
     "lint": "eslint index.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/disable-in-pc.js
+++ b/src/disable-in-pc.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+
+var VConsole = require('vconsole')
+
+const isPC = [
+  'Mac68K',
+  'MacPPC',
+  'Macintosh',
+  'MacIntel',
+  'Win32',
+  'Windows',
+].includes(window.navigator.platform)
+
+!isPC && window.vConsole === undefined && (window.vConsole = new VConsole())

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,9 +3,9 @@ import { WebpackPluginInstance, Compiler } from 'webpack'
 interface VConsolePluginOptions {
   filter: any[],
   /** 插件开关，默认“关” */
-  enable: false,
+  enable: boolean,
   /** 在 PC 环境禁用 */
-  disableInPC: false,
+  disableInPC: boolean,
 }
 
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,19 @@
+import { WebpackPluginInstance, Compiler } from 'webpack'
+
+interface VConsolePluginOptions {
+  filter: any[],
+  /** 插件开关，默认“关” */
+  enable: false,
+  /** 在 PC 环境禁用 */
+  disableInPC: false,
+}
+
+
+declare class VConsolePlugin implements WebpackPluginInstance {
+  constructor(opts?: VConsolePluginOptions)
+
+  apply: (compiler: Compiler) => void;
+}
+
+
+export = VConsolePlugin

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,11 +1,11 @@
 import { WebpackPluginInstance, Compiler } from 'webpack'
 
 interface VConsolePluginOptions {
-  filter: any[],
+  filter?: any[],
   /** 插件开关，默认“关” */
-  enable: boolean,
+  enable?: boolean,
   /** 在 PC 环境禁用 */
-  disableInPC: boolean,
+  disableInPC?: boolean,
 }
 
 


### PR DESCRIPTION
通常情况下，在 PC 端启用 VConsole 是多余的行为，VConsole 的log拦截还会导致 sourceMap 失效。

- 添加了`disableInPC` 选项， 在 PC 端浏览器中禁用 VConsole， 默认 `false`
- 添加了 TS 类型声明