### PR TITLE
make it easier to add custom vconsole plugin

### DIFF
--- a/src/vconsole.js
+++ b/src/vconsole.js
@@ -1,3 +1,4 @@
 var VConsole = require('vconsole');
 
 window.vConsole === undefined && (window.vConsole = new VConsole());
+window.VConsole === undefined && (window.VConsole = VConsole);


### PR DESCRIPTION
when adding a custom vconsole plugin, I have to import `vconsole` again
this will make it harder for "dead code elimination"

before:
```js
import VConsole from 'vconsole';
window.vConsole.addPlugin(myPlugin(VConsole));
```
after:
```js
window.vConsole.addPlugin(myPlugin(window.VConsole));
```