### PR TITLE
Treat failure case of readFileSync as no vConsole found in source

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,13 @@ function checkFilter(entries, filter) {
         if (!fs.existsSync(entries[i])) { // 处理 webpack-dev-server 开启的情况
             continue;
         }
-        const data = codeClean((fs.readFileSync(entries[i]) || '').toString());
+        
+        let data = ''
+        
+        try {
+            data = codeClean((fs.readFileSync(entries[i]) || '').toString());
+        } catch {}
+        
         if (data.toLowerCase().indexOf('new vconsole(') >= 0
             || data.indexOf('new require(\'vconsole') >= 0
             || data.indexOf('new require("vconsole') >= 0


### PR DESCRIPTION
For fixing the following issue

https://github.com/diamont1001/vconsole-webpack-plugin/issues/22

Treat error case of file reading as no data, so the plugin can continue work properly