### PR TITLE
fix: Handling case of entry is directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function checkFilter(entries, filter) {
         }
         
         if (fs.statSync(entries[i]).isDirectory()) {
-            return checkFilter(fs.readdirSync(entries[i], filter));
+            return checkFilter(fs.readdirSync(entries[i]), filter);
         }
 
         const data = codeClean((fs.readFileSync(entries[i]) || '').toString());


### PR DESCRIPTION
As the last night PR, it just only workaround to fix the problem https://github.com/diamont1001/vconsole-webpack-plugin/pull/69

This PR is fix the read root cause of the problem in issue https://github.com/diamont1001/vconsole-webpack-plugin/issues/22

Because of readFilesync is performed at the path that is directory not a file, so it is invalid operation for directory.

For the popular react starter library like razzle, it marks the entry as directory of client folder, so this PR can make this plugin work with razzle and other library that using entry as directory.